### PR TITLE
Making sure SessionRefreshPeriodically is run on client only

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -23,21 +23,21 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
   }
 
-  nuxtApp.hook('app:mounted', () => {
-    document.addEventListener('visibilitychange', visibilityHandler, false)
-  })
-
   // Refetch interval
   let refetchIntervalTimer: NodeJS.Timer
-
-  if (enableSessionRefreshPeriodically !== false) {
-    const intervalTime = enableSessionRefreshPeriodically === true ? 1000 : enableSessionRefreshPeriodically
-    refetchIntervalTimer = setInterval(() => {
-      if (data.value) {
-        getSession()
-      }
-    }, intervalTime)
-  }
+  
+  nuxtApp.hook('app:mounted', () => {
+    document.addEventListener('visibilitychange', visibilityHandler, false)
+    
+    if (enableSessionRefreshPeriodically !== false) {
+      const intervalTime = enableSessionRefreshPeriodically === true ? 1000 : enableSessionRefreshPeriodically
+      refetchIntervalTimer = setInterval(() => {
+        if (data.value) {
+          getSession()
+        }
+      }, intervalTime)
+    }
+  })
 
   const _unmount = nuxtApp.vueApp.unmount
   nuxtApp.vueApp.unmount = function () {


### PR DESCRIPTION
Again for this one, i am not sure of this has impact on other providers.
For my custom directus provider it gave the following error on the server

```
[nitro] [dev] [unhandledRejection] Error: nuxt instance unavailable
    at Module.useNuxtApp (/Users/***/developling.nl/node_modules/nuxt/dist/app/nuxt.mjs:165:13)
    at getSession (/Users/***/developling.nl/node_modules/@sidebase/nuxt-auth/dist/runtime/composables/useSession.mjs:95:38)
    at Timeout._onTimeout (/Users/***/developling.nl/node_modules/@sidebase/nuxt-auth/dist/runtime/plugin.mjs:31:9)
    at listOnTimeout (node:internal/timers:564:17)
    at process.processTimers (node:internal/timers:507:7)
    ```